### PR TITLE
Spl 54 group navigation

### DIFF
--- a/frontend/src/components/group/group/group.jsx
+++ b/frontend/src/components/group/group/group.jsx
@@ -5,6 +5,7 @@ import { toast } from 'react-toastify';
 import GroupActions from '../groupActions/groupActions';
 import { useDarkMode } from '../../../context/darkModeContext';
 import { useAuth } from '../../../context/userContextAuth';
+import { useNavigate } from 'react-router-dom';
 
 const Group = ({ group, setGroups }) => {
     const [expandedGroupId, setExpandedGroupId] = useState(null);
@@ -13,11 +14,16 @@ const Group = ({ group, setGroups }) => {
     const toggleMembers = (groupId) => {
         setExpandedGroupId(expandedGroupId === groupId ? null : groupId);
     };
+
+    const navigate = useNavigate();
     const { darkMode } = useDarkMode();
     const { token } = useAuth();
 
     const groupMembers = group?.members?.map((p) => p.user)
 
+    const handleActionsClick = (e) => {
+        e.stopPropagation();
+    }
 
     const handleEditGroup = async (data) => {
         try {
@@ -45,14 +51,14 @@ const Group = ({ group, setGroups }) => {
         }
     };
     return (
-        <div className={`${styles.group} ${darkMode ? styles.groupDark : ''}`} id={`group-card-${group._id}`}>
+        <div className={`${styles.group} ${darkMode ? styles.groupDark : ''}`} id={`group-card-${group._id}`} onClick={() => navigate(`/groups/${group._id}/expenses`)}>
             <li className={styles.listItem}>
                 <div className={styles.row} >
                     <div className={styles.left}>
                         <p><strong>{group.name}</strong></p>
                         <p>{group.description}</p>
                     </div>
-                    <div className={styles.right}>
+                    <div className={styles.right} onClick={handleActionsClick}>
                         <GroupActions group={group} groupMembers={groupMembers} editGroup={handleEditGroup} onDelete={onDelete} isEditing={isEditing} setIsEditing={setIsEditing} />
                     </div>
                 </div>

--- a/frontend/src/components/group/group/group.module.css
+++ b/frontend/src/components/group/group/group.module.css
@@ -5,6 +5,7 @@
     border-radius: 10px;
     border: 1px solid var(--border-color);
     width: 100%;
+    cursor: pointer;
     /* height: 60px;
     overflow: hidden;
     transition: height .3s;

--- a/frontend/src/components/group/groupActions/groupActions.jsx
+++ b/frontend/src/components/group/groupActions/groupActions.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import Modal from '../../modal/modal';
 import GroupForm from '../groupForm/groupForm';
 import Icon from '../../icon/icon';
@@ -18,8 +17,6 @@ const GroupActions = ({ group, groupMembers, editGroup, isEditing, setIsEditing,
         setAnchorEl(null);
     };
 
-    const navigate = useNavigate();
-
     const { darkMode } = useDarkMode();
 
 
@@ -33,7 +30,6 @@ const GroupActions = ({ group, groupMembers, editGroup, isEditing, setIsEditing,
                     transition: 'background-color 0.3s', '&:hover': { backgroundColor: darkMode ? '#09090b' : '', }
                 }
             }} id="basic-menu" anchorEl={anchorEl} open={open} onClose={handleClose} MenuListProps={{ 'aria-labelledby': 'basic-button', }}>
-                <MenuItem onClick={() => navigate(`/groups/${group._id}/expenses`)}><p>View details</p></MenuItem>
                 <MenuItem onClick={handleClose} >
                     <Button sx={{ color: darkMode ? '#FAFAFA' : 'black', minWidth: '0px', padding: '0', textTransform: 'none', fontSize: '16px', gap: '5px' }} onClick={() => setIsEditing(true)}>
                         <Icon variant='edit' />


### PR DESCRIPTION
Se ha eliminado la redirección desde el menú: Antes, era necesario hacer clic en el menú del grupo, seleccionar la opción de "View details" y luego se realizaba la redirección. Ahora, el onClick se ha movido al componente Group para acceder directamente a la página de detalles

Se ha añadido cursor: pointer al div del grupo para mejorar la experiencia del usuario y dejar claro que es un elemento clickeable.