### PR TITLE
feat: add confirmation toast hook

### DIFF
--- a/frontend/src/hooks/useConfirmationToast.jsx
+++ b/frontend/src/hooks/useConfirmationToast.jsx
@@ -1,0 +1,66 @@
+import { toast } from 'react-toastify';
+import { Button } from '@mui/material';
+
+export const useConfirmationToast = () => {
+    const showConfirmationToast = ({
+        message = "Are you sure?",
+        onConfirm,
+        confirmText = "Confirm",
+        cancelText = "Cancel",
+        confirmButtonProps = {},
+        cancelButtonProps = {}
+    }) => {
+        toast.info(
+            <div>
+                <p>{message}</p>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '10px' }}>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        size="small"
+                        onClick={() => {
+                            toast.dismiss();
+                            onConfirm();
+                        }}
+                        sx={{
+                            background: "#3c8ccd",
+                            borderRadius: "8px",
+                            textTransform: "none",
+                            fontWeight: "bold",
+                            "&:hover": { background: "#1e90ff" },
+                            ...confirmButtonProps.sx
+                        }}
+                        {...confirmButtonProps}
+                    >
+                        {confirmText}
+                    </Button>
+                    <Button
+                        variant="outlined"
+                        color="error"
+                        size="small"
+                        onClick={() => {
+                            toast.dismiss();
+                        }}
+                        sx={{
+                            borderRadius: "8px",
+                            textTransform: "none",
+                            fontWeight: "bold",
+                            ...cancelButtonProps.sx
+                        }}
+                        {...cancelButtonProps}
+                    >
+                        {cancelText}
+                    </Button>
+                </div>
+            </div>,
+            {
+                autoClose: false,
+                closeOnClick: false,
+                draggable: false,
+                closeButton: true
+            }
+        );
+    };
+
+    return { showConfirmationToast };
+};


### PR DESCRIPTION
### **Descripción**
Este PR introduce un hook personalizado (useConfirmationToast) que proporciona un diálogo de confirmación reutilizable utilizando react-toastify.

### **Cambios clave**
- Creado el hook useConfirmationToast para mostrar los toast de confirmación.
- Añadidos botones personalizables (Confirmar y Cancelar) usando Material UI.
- Se ha implementado toast.dismiss() para garantizar que sólo aparezca un toast cada vez.
- Se ha habilitado la personalización de botones mediante confirmButtonProps y cancelButtonProps para flexibilizar el estilo y el comportamiento.