### PR TITLE
Spl 49 pay button

### DIFF
--- a/frontend/src/components/debts/debt/debt.jsx
+++ b/frontend/src/components/debts/debt/debt.jsx
@@ -1,13 +1,46 @@
+import { Button } from '@mui/material';
 import { useDarkMode } from '../../../context/darkModeContext';
 import styles from './debt.module.css'
-const Debt = ({ debt }) => {
+import { useAuth } from '../../../context/userContextAuth';
+import { updatePayment } from '../../../utils/paymentApi';
+import { toast } from 'react-toastify';
+import { useConfirmationToast } from '../../../hooks/useConfirmationToast';
+const Debt = ({ debt, refreshGroupDetails }) => {
     const { darkMode } = useDarkMode();
+    const { token } = useAuth();
+    const { showConfirmationToast } = useConfirmationToast();
+
+    const handlePayDebt = async () => {
+        showConfirmationToast({
+            message: `Are you sure you want to mark this debt as paid?`,
+            onConfirm: confirmPayment,
+        });
+    };
+
+    const confirmPayment = async () => {
+        try {
+            await updatePayment(debt._id, token);
+            toast.success('Debt marked as paid');
+            refreshGroupDetails();
+        } catch (error) {
+            toast.error(error.response.data.error || 'Something went wrong');
+        }
+    };
 
     return (
         <>
             <div className={`${styles.debt} ${darkMode ? styles.debtDark : ''}`}>
                 <p>{debt.from.name} owes <strong>{debt.amount}€</strong> to {debt.to.name}</p>
-            </div>
+                <Button
+                    variant="contained"
+                    color="primary"
+                    size="small"
+                    onClick={handlePayDebt}
+                    sx={{ background: "#3c8ccd", borderRadius: "8px", textTransform: "none", fontWeight: "bold", "&:hover": { background: "#1e90ff" } }}
+                >
+                    Mark as paid
+                </Button>
+            </div >
         </>
     )
 }

--- a/frontend/src/components/debts/debt/debt.module.css
+++ b/frontend/src/components/debts/debt/debt.module.css
@@ -1,4 +1,7 @@
 .debt {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     padding: 15px;
     background-color: #f0f0f0;
     border-radius: 10px;

--- a/frontend/src/components/debts/debtsList.jsx
+++ b/frontend/src/components/debts/debtsList.jsx
@@ -1,14 +1,14 @@
 import styles from './debtsList.module.css'
 import Debt from "./debt/debt";
 
-const DebtsList = ({ groupDebts }) => {
+const DebtsList = ({ groupDebts, refreshGroupDetails }) => {
     return (
         <div className={styles.debtsList}>
             <div>
                 {groupDebts?.length === 0 ? '' : (
                     <ul className={styles.list}>
                         {groupDebts?.map((debt) => (
-                            <Debt key={debt._id} debt={debt} />
+                            <Debt key={debt._id} debt={debt} refreshGroupDetails={refreshGroupDetails} />
                         ))}
                     </ul>
                 )}

--- a/frontend/src/pages/groups/groupDetails/groupDetails.jsx
+++ b/frontend/src/pages/groups/groupDetails/groupDetails.jsx
@@ -38,7 +38,7 @@ const GroupDetails = () => {
             <BalanceList groupBalance={data.balance} />
             <div className={styles.grid}>
                 <ExpenseList groupExpenses={data.expenses} refreshGroupDetails={refreshGroupDetails} />
-                <DebtsList groupDebts={data.debts} />
+                <DebtsList groupDebts={data.debts} refreshGroupDetails={refreshGroupDetails} />
             </div>
             <CreateExpense refreshGroupDetails={refreshGroupDetails} />
         </div>

--- a/frontend/src/utils/paymentApi.js
+++ b/frontend/src/utils/paymentApi.js
@@ -1,0 +1,7 @@
+import { authHeaders } from "./authHeaders";
+import api from "./axios";
+
+export const updatePayment = async (paymentId, token) => {
+    const response = await api.patch(`/payment/${paymentId}`, {}, authHeaders(token));
+    return response.data;
+};


### PR DESCRIPTION
Descripción

Este PR introduce la funcionalidad de actualización de pagos e integra toasts de confirmación para gestionar el pago de deudas.  Además, garantiza que los componentes relacionados con `groupDetails` se actualicen correctamente tras una actualización de pago.


Cambios clave

- Añadida la función updatePayment para gestionar las actualizaciones de pagos en la API.
- Integrado useConfirmationToast para solicitar confirmación antes de marcar una deuda como pagada.
- Actualizado el componente Debts:  
  - Se ha añadido un diálogo de confirmación antes de actualizar el estado del pago.
  - Se ha pasado refreshGroupDetails para actualizar los detalles del grupo tras el pago.
  - Se ha utilizado useAuth para recuperar el token de autenticación.
  - Se ha mejorado el diseño con display: flex para una mejor alineación.

- Actualizados DebtsList y GroupDetails:
  - Se ha pasado refreshGroupDetails a los componentes hijos para asegurar la actualización de datos adecuada después de pago.