### PR TITLE
Spl 58 error handling

### DIFF
--- a/backend/src/controllers/group.controller.js
+++ b/backend/src/controllers/group.controller.js
@@ -188,8 +188,7 @@ const deleteGroup = async (req, res) => {
     await Group.findByIdAndDelete(groupId);
     res.status(204).send();
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ success: false, message: "Error deleting group" });
+    res.status(500).json({ error: 'Error deleting group' });
   }
 };
 

--- a/frontend/src/components/expense/expense/expense.jsx
+++ b/frontend/src/components/expense/expense/expense.jsx
@@ -27,7 +27,7 @@ const Expense = ({ expense, refreshGroupDetails }) => {
             refreshGroupDetails();
             toast.success('Expense succesfully edited');
         } catch (error) {
-            toast.error(error.response.data.error);
+            toast.error(error.response.data.error || 'there was an error editing the expense');
         }
     }
 
@@ -42,7 +42,7 @@ const Expense = ({ expense, refreshGroupDetails }) => {
             refreshGroupDetails();
             toast.success('Expense succesfully deleted');
         } catch (error) {
-            toast.error(error.response.data.error);
+            toast.error(error.response.data.error || 'there was an error deleting the expense');
         }
     };
 

--- a/frontend/src/components/group/group/group.jsx
+++ b/frontend/src/components/group/group/group.jsx
@@ -32,7 +32,7 @@ const Group = ({ group, setGroups }) => {
             setIsEditing(false);
             toast.success('Group successfully edited');
         } catch (error) {
-            toast.error(error.response.data.error)
+            toast.error(error.response.data.error || 'there was an error editing the group');
         }
     }
 
@@ -47,7 +47,7 @@ const Group = ({ group, setGroups }) => {
             setGroups((prevGroups) => prevGroups.filter((g) => g._id !== group._id));
             toast.success('Group succesfully deleted')
         } catch (error) {
-            toast.error(error.response.data.error)
+            toast.error(error.response.data.error || 'there was an error deleting the group');
         }
     };
     return (


### PR DESCRIPTION
Descripción

Este PR mejora el manejo de errores y la consistencia de las respuestas tanto en el backend (endpoint deleteGroup) como en el frontend (funciones handleEditGroup, onDelete, updateGroupExpense y deleteGroupExpense).

Cambios clave

- Actualización del formato de respuesta de error en deleteGroup (Backend)

  - Se cambió { success: false, } a { error: 'mensaje' } para mantener la consistencia en el manejo de errores de la API.
  - Se asegura que los mensajes de error sigan una estructura uniforme en toda la API.
  
- Mejora en el manejo de errores en las acciones de edición y eliminación (Frontend)

  - Se garantiza que toast.error siempre muestre un mensaje, incluso si error.response.data.error es undefined.
  - Evita que los errores no sean visibles cuando la API no devuelve un mensaje de error adecuado.