### PR TITLE
SPL 63 confirmation toast

### DIFF
--- a/frontend/src/components/expense/expense/expense.jsx
+++ b/frontend/src/components/expense/expense/expense.jsx
@@ -6,6 +6,7 @@ import ExpenseActions from '../expenseActions/expenseActions';
 import { useDarkMode } from '../../../context/darkModeContext';
 import { useAuth } from '../../../context/userContextAuth';
 import { Avatar } from '@mui/material';
+import { useConfirmationToast } from '../../../hooks/useConfirmationToast';
 
 const Expense = ({ expense, refreshGroupDetails }) => {
     const [expandedExpenseId, setExpandedExpenseId] = useState(null);
@@ -13,6 +14,7 @@ const Expense = ({ expense, refreshGroupDetails }) => {
 
     const { darkMode } = useDarkMode();
     const { token } = useAuth();
+    const { showConfirmationToast } = useConfirmationToast();
 
     const groupMembers = expense.group.members.map((member) => member.user);
 
@@ -31,12 +33,14 @@ const Expense = ({ expense, refreshGroupDetails }) => {
         }
     }
 
-    const onDelete = async () => {
-        const userConfirmed = window.confirm('Are you sure you want to delete this expense?');
-        if (!userConfirmed) {
-            return;
-        }
+    const handleDeleteExpense = async () => {
+        showConfirmationToast({
+            message: `Are you sure you want to delete this expense?`,
+            onConfirm: onDelete,
+        });
+    };
 
+    const onDelete = async () => {
         try {
             await deleteGroupExpense(expense.group._id, expense._id, token);
             refreshGroupDetails();
@@ -60,7 +64,7 @@ const Expense = ({ expense, refreshGroupDetails }) => {
                     <div className={styles.right}>
                         <p><strong>{expense.totalAmount}€</strong></p>
                         <div className={styles.actions}>
-                            <ExpenseActions groupMembers={groupMembers} handleEditExpense={handleEditExpense} onDelete={onDelete} isEditing={isEditing} setIsEditing={setIsEditing} defaultValues={expense} />
+                            <ExpenseActions groupMembers={groupMembers} handleEditExpense={handleEditExpense} onDelete={handleDeleteExpense} isEditing={isEditing} setIsEditing={setIsEditing} defaultValues={expense} />
                         </div>
                     </div>
                 </div>

--- a/frontend/src/components/group/group/group.jsx
+++ b/frontend/src/components/group/group/group.jsx
@@ -6,6 +6,7 @@ import GroupActions from '../groupActions/groupActions';
 import { useDarkMode } from '../../../context/darkModeContext';
 import { useAuth } from '../../../context/userContextAuth';
 import { useNavigate } from 'react-router-dom';
+import { useConfirmationToast } from '../../../hooks/useConfirmationToast';
 
 const Group = ({ group, setGroups }) => {
     const [expandedGroupId, setExpandedGroupId] = useState(null);
@@ -18,6 +19,7 @@ const Group = ({ group, setGroups }) => {
     const navigate = useNavigate();
     const { darkMode } = useDarkMode();
     const { token } = useAuth();
+    const { showConfirmationToast } = useConfirmationToast();
 
     const groupMembers = group?.members?.map((p) => p.user)
 
@@ -36,12 +38,14 @@ const Group = ({ group, setGroups }) => {
         }
     }
 
-    const onDelete = async () => {
-        const userConfirmed = window.confirm('Are you sure you want to delete this group?');
-        if (!userConfirmed) {
-            return;
-        }
+    const handleDeleteExpense = async () => {
+        showConfirmationToast({
+            message: `Are you sure you want to delete this group?`,
+            onConfirm: onDelete,
+        });
+    };
 
+    const onDelete = async () => {
         try {
             await deleteGroup(group._id, token);
             setGroups((prevGroups) => prevGroups.filter((g) => g._id !== group._id));
@@ -59,7 +63,7 @@ const Group = ({ group, setGroups }) => {
                         <p>{group.description}</p>
                     </div>
                     <div className={styles.right} onClick={handleActionsClick}>
-                        <GroupActions group={group} groupMembers={groupMembers} editGroup={handleEditGroup} onDelete={onDelete} isEditing={isEditing} setIsEditing={setIsEditing} />
+                        <GroupActions group={group} groupMembers={groupMembers} editGroup={handleEditGroup} onDelete={handleDeleteExpense} isEditing={isEditing} setIsEditing={setIsEditing} />
                     </div>
                 </div>
                 {expandedGroupId === group._id && (


### PR DESCRIPTION
### **Descripción**
Este PR mejora la experiencia de usuario reemplazando los diálogos nativos de window.confirm por modales de confirmación personalizados mediante toasts, utilizando el hook useConfirmationToast.

### Cambios clave

- Eliminación de Gastos:

  - Se reemplazó window.confirm por una confirmación basada en toast al eliminar gastos.
  - Mejora la experiencia del usuario y se integra mejor con el sistema de notificaciones de la app.

- Eliminación de Grupos:
  
  - Se reemplazó window.confirm por useConfirmationToast para confirmar la eliminación de grupos.
  - Mejora la experiencia del usuario y se integra mejor con el sistema de notificaciones de la app.
