### PR TITLE
Spl 64 subtitles

### DIFF
--- a/frontend/src/components/balance/balanceList/balanceList.module.css
+++ b/frontend/src/components/balance/balanceList/balanceList.module.css
@@ -3,7 +3,7 @@
 }
 
 .title {
-    font-size: 14px;
+    font-size: 16px;
     color: #1e90ff;
     margin-bottom: 10px;
 }

--- a/frontend/src/components/debts/debtsList.jsx
+++ b/frontend/src/components/debts/debtsList.jsx
@@ -6,11 +6,14 @@ const DebtsList = ({ groupDebts, refreshGroupDetails }) => {
         <div className={styles.debtsList}>
             <div>
                 {groupDebts?.length === 0 ? '' : (
-                    <ul className={styles.list}>
-                        {groupDebts?.map((debt) => (
-                            <Debt key={debt._id} debt={debt} refreshGroupDetails={refreshGroupDetails} />
-                        ))}
-                    </ul>
+                    <>
+                        <h2 className={styles.title}>Debts</h2>
+                        <ul className={styles.list}>
+                            {groupDebts?.map((debt) => (
+                                <Debt key={debt._id} debt={debt} refreshGroupDetails={refreshGroupDetails} />
+                            ))}
+                        </ul>
+                    </>
                 )}
             </div>
         </div>

--- a/frontend/src/components/debts/debtsList.module.css
+++ b/frontend/src/components/debts/debtsList.module.css
@@ -1,0 +1,5 @@
+.title {
+    font-size: 16px;
+    color: #1e90ff;
+    margin-bottom: 10px;
+}

--- a/frontend/src/components/expense/expenseList/expenseList.jsx
+++ b/frontend/src/components/expense/expenseList/expenseList.jsx
@@ -1,16 +1,19 @@
 import styles from './expenseList.module.css'
 import Expense from '../expense/expense';
 
-const ExpenseList = ({ groupExpenses, refreshGroupDetails, className }) => {
+const ExpenseList = ({ groupExpenses, refreshGroupDetails, className, title = true }) => {
     return (
         <section className={styles.expenses}>
             <div>
                 {groupExpenses?.length === 0 ? (<p>There are no expenses in this group</p>) : (
-                    <ul className={className ? [styles[className]] : styles.detailsList}>
-                        {groupExpenses?.map((item) => (
-                            <Expense key={item._id} expense={item} refreshGroupDetails={refreshGroupDetails} />
-                        ))}
-                    </ul>
+                    <>
+                        {title && <h2 className={styles.title}>Expenses</h2>}
+                        <ul className={className ? [styles[className]] : styles.detailsList}>
+                            {groupExpenses?.map((item) => (
+                                <Expense key={item._id} expense={item} refreshGroupDetails={refreshGroupDetails} />
+                            ))}
+                        </ul>
+                    </>
                 )}
             </div>
         </section>

--- a/frontend/src/components/expense/expenseList/expenseList.module.css
+++ b/frontend/src/components/expense/expenseList/expenseList.module.css
@@ -1,3 +1,9 @@
+.title {
+    font-size: 16px;
+    color: #1e90ff;
+    margin-bottom: 10px;
+}
+
 .list {
     display: grid;
     grid-template-columns: repeat(1, 1fr);

--- a/frontend/src/components/userExpenses/userExpenses.jsx
+++ b/frontend/src/components/userExpenses/userExpenses.jsx
@@ -36,7 +36,7 @@ const UserExpenses = () => {
             {data?.map((group) => (
                 <div key={group.groupId}>
                     <h2 className={styles.title} onClick={() => navigate(`/groups/${group.groupId}/expenses`)}>{group.groupName}</h2>
-                    <ExpenseList groupExpenses={group.expenses} refreshGroupDetails={refreshExpenses} className='list' />
+                    <ExpenseList groupExpenses={group.expenses} refreshGroupDetails={refreshExpenses} className='list' title={false} />
                 </div>
             ))}
         </div>


### PR DESCRIPTION
**### Descripción**
Mejora de títulos en secciones de balance, gastos y deudas

**Cambios clave**

- BalanceList
  - Se aumentó el tamaño de fuente del título de 14px a 16px para mejorar la visibilidad.

- DebtsList
  - Se añadió un título para la sección de deudas.
  - Se aplicaron estilos al título (tamaño de fuente y color) para mantener consistencia visual.

- ExpenseList
  - Se añadió un título opcional para la sección de gastos, visible por defecto.
  - Se incluyó una prop title={false} para poder ocultarlo cuando sea necesario (ej. en UserExpenses).
  - Se añadieron estilos al título para mejorar la UI.

- UserExpenses
  - Se desactivó la visualización del título en la lista de gastos utilizando la nueva prop title={false}.