### PR TITLE
Spl 65 tooltip

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "react-query": "^3.39.3",
     "react-router-dom": "^7.1.1",
     "react-toastify": "^11.0.3",
+    "react-tooltip": "^5.28.0",
     "socket.io-client": "^4.8.1"
   },
   "devDependencies": {

--- a/frontend/src/components/expense/expense/expense.jsx
+++ b/frontend/src/components/expense/expense/expense.jsx
@@ -7,9 +7,9 @@ import { useDarkMode } from '../../../context/darkModeContext';
 import { useAuth } from '../../../context/userContextAuth';
 import { Avatar } from '@mui/material';
 import { useConfirmationToast } from '../../../hooks/useConfirmationToast';
+import { Tooltip } from 'react-tooltip';
 
 const Expense = ({ expense, refreshGroupDetails }) => {
-    const [expandedExpenseId, setExpandedExpenseId] = useState(null);
     const [isEditing, setIsEditing] = useState(false);
 
     const { darkMode } = useDarkMode();
@@ -17,10 +17,6 @@ const Expense = ({ expense, refreshGroupDetails }) => {
     const { showConfirmationToast } = useConfirmationToast();
 
     const groupMembers = expense.group.members.map((member) => member.user);
-
-    const toggleParticipants = (expenseId) => {
-        setExpandedExpenseId(expandedExpenseId === expenseId || isEditing ? null : expenseId);
-    };
 
     const handleEditExpense = async (data) => {
         try {
@@ -52,13 +48,14 @@ const Expense = ({ expense, refreshGroupDetails }) => {
 
     return (
         <div className={`${styles.expense} ${darkMode ? styles.expenseDark : ''}`}>
-            <li className={styles.listItem} onClick={() => toggleParticipants(expense._id)} title='click to see the details'>
+            <li className={styles.listItem}>
                 <div className={styles.row}>
                     <div className={styles.left}>
                         <p><strong>{expense.description}</strong></p>
-                        <div className={styles.paidBy} title={expense.paidBy.name}>
+                        <div className={styles.paidBy}>
                             <p>Paid by</p>
-                            <Avatar src={expense.paidBy.profilePicture} alt="" />
+                            <Avatar src={expense.paidBy.profilePicture} alt={`Profile picture of ${expense.paidBy.name}`} data-tooltip-id={expense.paidBy._id} sx={{ backgroundColor: 'white' }} />
+                            <Tooltip id={expense.paidBy._id} content={expense.paidBy.name} />
                         </div>
                     </div>
                     <div className={styles.right}>
@@ -68,18 +65,6 @@ const Expense = ({ expense, refreshGroupDetails }) => {
                         </div>
                     </div>
                 </div>
-                {expandedExpenseId === expense._id && (
-                    <div className={styles.participants}>
-                        <p><strong>Participants</strong></p>
-                        <ul>
-                            {expense.participants.map((participant, index) => (
-                                <li key={index} className={styles.listItem}>
-                                    {participant.user.name} {participant.amountOwed}€
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                )}
             </li>
         </div>
     );

--- a/frontend/src/components/expense/expense/expense.module.css
+++ b/frontend/src/components/expense/expense/expense.module.css
@@ -26,8 +26,6 @@
 
 .listItem {
     list-style: none;
-    /* color: white; */
-    cursor: pointer;
 }
 
 .row {

--- a/frontend/src/components/userExpenses/userExpenses.jsx
+++ b/frontend/src/components/userExpenses/userExpenses.jsx
@@ -4,7 +4,8 @@ import { useAuth } from "../../context/userContextAuth";
 import { getAllUserExpenses } from "../../utils/expenseApi";
 import ExpenseList from "../expense/expenseList/expenseList";
 import { toast } from "react-toastify";
-import styles from './userExpenses.module.css'
+import styles from './userExpenses.module.css';
+import { Tooltip } from 'react-tooltip';
 
 
 const UserExpenses = () => {
@@ -35,7 +36,8 @@ const UserExpenses = () => {
         <div>
             {data?.map((group) => (
                 <div key={group.groupId}>
-                    <h2 className={styles.title} onClick={() => navigate(`/groups/${group.groupId}/expenses`)}>{group.groupName}</h2>
+                    <h2 className={styles.title} onClick={() => navigate(`/groups/${group.groupId}/expenses`)} data-tooltip-id={group.groupId}>{group.groupName}</h2>
+                    <Tooltip id={group.groupId} content="Click to view group details" />
                     <ExpenseList groupExpenses={group.expenses} refreshGroupDetails={refreshExpenses} className='list' title={false} />
                 </div>
             ))}


### PR DESCRIPTION
**### Descripción**
Esta PR mejora la interfaz de usuario integrando tooltips para una mejor interactividad y claridad. Además, elimina estilos innecesarios del componente de gastos.

**### Cambios Clave**

- Añadida la dependencia react-tooltip
- Permite el uso de tooltips en toda la aplicación.

- Tooltip en el componente de gastos
  - Muestra el nombre del pagador al pasar el ratón por su avatar.

- Tooltip en los nombres de grupo en UserExpenses
  - Añade un tooltip informativo al pasar el ratón por encima del nombre del grupo que redirige a la vista de detalles del grupo.

- Eliminación de estilos no utilizados en el módulo de estilos de Expense