### PR TITLE
SPL-68-FIX/create-group

### DIFF
--- a/frontend/src/components/group/createGroup/createGroup.jsx
+++ b/frontend/src/components/group/createGroup/createGroup.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { createGroup } from "../../../utils/groupApi";
 import GroupForm from "../groupForm/groupForm";
 import Icon from "../../icon/icon";
@@ -6,6 +6,7 @@ import Modal from "../../modal/modal";
 import { toast } from "react-toastify";
 import { useAuth } from "../../../context/userContextAuth";
 import { getUserSession } from "../../../utils/localStorage";
+import { useNavigate } from "react-router-dom";
 
 
 const CreateGroup = ({ setGroups }) => {
@@ -13,17 +14,19 @@ const CreateGroup = ({ setGroups }) => {
     const openModal = () => setIsModalOpen(true);
     const closeModal = () => setIsModalOpen(false);
 
-    const { token } = useAuth();
+    const { token, logout } = useAuth();
+    const navigate = useNavigate();
 
-    let email
-    if (token) {
-        const session = getUserSession();
-        if (session) {
-            email = session.email;
-        } else {
-            window.location.reload();
+    useEffect(() => {
+        if (token) {
+            const session = getUserSession();
+            const email = session?.email;
+            if (!email) {
+                logout();
+                navigate('/login');
+            }
         }
-    }
+    }, [token, logout, navigate]);
 
     const handleCreateGroup = async (data) => {
         try {

--- a/frontend/src/components/group/createGroup/createGroup.jsx
+++ b/frontend/src/components/group/createGroup/createGroup.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { createGroup } from "../../../utils/groupApi";
 import GroupForm from "../groupForm/groupForm";
 import Icon from "../../icon/icon";
@@ -13,8 +13,17 @@ const CreateGroup = ({ setGroups }) => {
     const openModal = () => setIsModalOpen(true);
     const closeModal = () => setIsModalOpen(false);
 
-    const { email } = getUserSession()
     const { token } = useAuth();
+
+    let email
+    if (token) {
+        const session = getUserSession();
+        if (session) {
+            email = session.email;
+        } else {
+            window.location.reload();
+        }
+    }
 
     const handleCreateGroup = async (data) => {
         try {
@@ -27,7 +36,7 @@ const CreateGroup = ({ setGroups }) => {
             closeModal();
             toast.success('Group succesfully created')
         } catch (error) {
-            toast.error(error.response.data.error)
+            toast.error(error.response.data.error || 'there was an error creating the group')
         }
     }
 


### PR DESCRIPTION
### **Descripción**
Este PR corrige un error que se producía al intentar crear un grupo sin una sesión de usuario válida. Anteriormente, si se eliminaba el localStorage, la aplicación intentaba desestructurar email de getUserSession() sin validación previa, lo que provocaba que la app se rompiera y se quedara en blanco.

### **Cambios clave**

- Verificación de la existencia de una sesión válida antes de extraer email del local storage.
- Si session o email no está presente en el local storage, se ejecuta el logout() y se redirige automáticamente al login.
- Se evita el error de desestructuración que dejaba la app en blanco.
- Mejora del mensaje de error por defecto con toast.error para una mejor experiencia de usuario.