### PR TITLE
SPL-69-fix/create-group

### DIFF
--- a/frontend/src/components/group/createGroup/createGroup.jsx
+++ b/frontend/src/components/group/createGroup/createGroup.jsx
@@ -11,6 +11,7 @@ import { useNavigate } from "react-router-dom";
 
 const CreateGroup = ({ setGroups }) => {
     const [isModalOpen, setIsModalOpen] = useState(false);
+    const [email, setEmail] = useState(null);
     const openModal = () => setIsModalOpen(true);
     const closeModal = () => setIsModalOpen(false);
 
@@ -20,10 +21,12 @@ const CreateGroup = ({ setGroups }) => {
     useEffect(() => {
         if (token) {
             const session = getUserSession();
-            const email = session?.email;
-            if (!email) {
+            const userEmail = session?.email;
+            if (!userEmail) {
                 logout();
                 navigate('/login');
+            } else {
+                setEmail(userEmail)
             }
         }
     }, [token, logout, navigate]);


### PR DESCRIPTION
### **Descripción**
Esta PR soluciona un problema donde la propiedad createdBy enviada al componente GroupForm podía ser undefined

### **Cambios clave**

- Se reemplaza la obtención directa del email por una variable de estado (useState) para asegurar que esté disponible al momento de renderizar el modal.
- Se utiliza useEffect para extraer el email del sessionStorage y actualizar el estado.